### PR TITLE
docs: 이메일 인증 방식을 Google로 수정

### DIFF
--- a/src/main/java/com/flag/flag_back/Controller/MailController.java
+++ b/src/main/java/com/flag/flag_back/Controller/MailController.java
@@ -77,7 +77,8 @@ public class MailController {
 
         // 이메일 전송 설정
         SimpleMailMessage mailMessage = new SimpleMailMessage();
-        mailMessage.setFrom("팀계정@naver.com"); //Flag팀 계정으로 수정
+        //mailMessage.setFrom("0@naver.com"); //Flag팀 계정으로 수정
+        mailMessage.setFrom("team.flagapp@gmail.com");  //Flag팀 계정으로 수정
         mailMessage.setTo(user.getEmail());
         mailMessage.setSubject("Flag 임시비밀번호가 발급되었습니다.");
         mailMessage.setText("Flag 임시 비밀번호:\n" + temporaryPassword);

--- a/src/main/java/com/flag/flag_back/config/MailConfig.java
+++ b/src/main/java/com/flag/flag_back/config/MailConfig.java
@@ -42,7 +42,7 @@ public class MailConfig {
         props.put("mail.smtp.auth", auth);
         props.put("mail.smtp.starttls.enable", starttlsEnable);
         props.put("mail.debug", "true");
-        props.put("mail.smtp.ssl.enable", "true");
+        //props.put("mail.smtp.ssl.enable", "true"); //naver용
 
         return mailSender;
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,19 +34,30 @@ spring:
     suffix: .html
     check-template-location: true
 
+  #  mail:
+  #    host: smtp.naver.com
+  #    port: 465
+  #    username: username #Flag naver계정
+  #    password: password #Flag 계정비밀번호
+  #    properties:
+  #      mail:
+  #        smtp:
+  #          auth: true
+  #          timeout: 5000
+  #          starttls:
+  #            enable: true
   mail:
-    host: smtp.naver.com
-    port: 465
-    username: username #Flag naver계정
-    password: password #Flag 계정비밀번호
+    host: smtp.gmail.com # SMTP 서버 호스트
+    port: 587 # SMTP 서버 포트
+    username: team.flagapp # SMTP 서버 로그인 아이디 (발신자)
+    password: oewkvwbgucfdqmyb # SMTP 서버 로그인 패스워드 (앱 비밀번호)
     properties:
       mail:
         smtp:
-          auth: true
-          timeout: 5000
+          auth: true # 사용자 인증 시도 여부 (기본값 : false)
+          timeout: 5000 # Socket Read Timeout 시간(ms) (기본값 : 무한대)
           starttls:
-            enable: true
-
+            enable: true # StartTLS 활성화 여부 (기본값 : false)
   mvc:
     pathmatch:
       matching-strategy: ant_path_matcher


### PR DESCRIPTION
docs: 이메일 인증 방식을 Naver에서 Google로 변경하는 내용으로 수정
구글 2단계 인증, 앱 비밀번호 생성 Gmail 설정[ POP/IMAP] 후 코드 수정
security post설정으로 인해 403오류 발생-이 부분만 수정하면 될 것 같음.